### PR TITLE
Simpler create method parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Support PHP v8.
+- New method `createEmailTestForClients()` as the recommended and simpler way to
+  create new tests with just an array of EmailClient ApplicationNames.
 - Type declarations to all methods and properties.
 - Namespaced exceptions for errors thrown within this package.
 - Throw `NotFoundException` for `getEmailTest()` and `getResult()` when Litmus
@@ -16,6 +18,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Creating callback object from XML did not correctly read boolean values.
 ### Changed
 - **BC break**: Namespace changed to `Phlib\LitmusResellerSDK`.
+- **BC break**: Simplify the paramters for `createEmailTest()` to accept a list
+  of client ApplicationNames and sandbox flag in native types. The previous
+  behaviour is deprecated and available as `createEmailTestRaw()`.
 - **BC break**: Callback result objects are created using `Callback\Factory`.
 - Change licence to LGPLv3 to match other Phlib projects.
 ### Removed

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ composer require phlib/litmus-reseller-sdk
 See the [Legacy litmus SOAP API docs](https://litmus.github.io/legacy-litmus-api-docs/SOAP/Legacy%20SOAP%20Web%20Service%3A%20Process%20for%20running%20email%20tests)
 for an example workflow.
 
-* Create an empty `EmailTest` object and pass it to `Litmus::createEmailTest()`.
+* Call `Litmus::createEmailTest()`.
 * This will return a new `EmailTest` object containing the unique ID.
 * The ID can be used when calling `Litmus::getEmailTest()` to view the state.
 * The `EmailTest::getResults()` method can be used to get details on the state

--- a/src/Litmus.php
+++ b/src/Litmus.php
@@ -53,7 +53,30 @@ class Litmus
         return $clients;
     }
 
-    public function createEmailTest(EmailTest $EmailTest): EmailTest
+    public function createEmailTest(array $clientNames = [], bool $sandbox = false)
+    {
+        $clients = [];
+        foreach ($clientNames as $applicationName) {
+            $clients[] = new EmailClient([
+                'ApplicationName' => $applicationName,
+            ]);
+        }
+
+        $emailTest = new EmailTest([
+            'Sandbox' => $sandbox,
+            'Results' => $clients,
+        ]);
+
+        return $this->createEmailTestRaw($emailTest);
+    }
+
+    /**
+     * @deprecated 3.0.0 This behaviour was previously available as `createEmailTest()`
+     *     but left here for any implementations that need non-standard behaviour
+     *     and may be removed in future if no use-cases are shown.
+     * @see createEmailTest()
+     */
+    public function createEmailTestRaw(EmailTest $EmailTest): EmailTest
     {
         $result = $this->soapClient->__soapCall('CreateEmailTest', [
             $this->apiKey,


### PR DESCRIPTION
- Modify create method to take simpler parameters.
- The old behaviour is left as a deprecated method.